### PR TITLE
Travis artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,10 @@ before_install:
 script: if [[ "$CC" == "i686-w64-mingw32-gcc" ]] && [[ "$TRAVIS_OS_NAME" == "osx"
   ]]; then make CC=${CC} cli; else make CC=${CC} ; fi
 addons:
-  artifacts:
-    s3_region: "eu-west-2"
+  artifacts: true
 env:
   global:
   - ARTIFACTS_PATHS="./bin:./libs"
-  - ARTIFACTS_BUCKET=cucumber-releases
+  - ARTIFACTS_BUCKET=cucumber-oss
   - secure: aaC95l0Tq63040to71E2WGQHGyW+5qq9T0cujbgtx7UlVKq3XJ4IdPt+gT+GO9EddLkrrQ+09T27G56RO9hjfLWd3Xxf4+TCIhUQUEp5yD2ApLBP/BM4UeRgwjZKaxdtXsLcv8B8FNWAlZ0IyvA6TssZLge2gXIECm7yfJFJlQhjP0exmP5AN1YaC8IV8KwNT2rx8JZo5Q2nERKH0MCtuPCGdAIBCqZbrYwLj//FMl+YSTuzpAGiqXXosgSIsNJwIrKNJckEMoB7ZDWLCsCdzSZKNabpPd1yqwNxM/5zncfQ7V0oXx6mY2iusR64d8Icq5HAdGe9g2Pwpsme1Ptydiw19dwFaxs1PSJwFRiRhkMZIRZFHzyCpOZg9Zr1uftyPmV7RfKI0FUvmkuYGF0VxDXwP7B/nKWTSNqBvTlZ48O5b3rslNLqFf20WF1Qvll2IZ3Dmj8tcZYa1Rr9fivWnCKUZVfcADG98lcyVgpi9sojb4nvGLGB7Ux8tQt9Ka0jfp/7eaXAf8LLGDXYSj1VHKw94vgnM0ESsjTFBMLUtjymvUaQPGZeiIzcA8m6jo6Sjatg+GBZKADZo4R351BotUWzsLCyYfS0k+HJFpKKjPFKdFZob+6B5yJUk18Xcnj3vo+P0L6v2EpEE70qzQuAmCFTUXpVPAqoYtnxko10i4Y=
   - secure: Cm9A5zBoy2rbgTeh+70ZGyWgnoeiLzQwKPrC9EksWUNuOzTEfAsV5+2c+owb6DKshoI6tGye3tl61q36A1nhJgZ/DyjDoIOa+hi+IAbBw4u0CbFjEEbdbGxyoe0PbcBaLgDFMnvA1wzITisfhdVNoOhQIO+DhsuhpVn/fj14hUdi1s4vujSwZLIPPWUe7FT0B4tIsV0+wBflGdLa55j3oEIB6CyMFaa2v5xTFdqteiWlfapojJGQ20VQz9TerJFFdIMyKiPb5shsO9zd1ioxZRpL7iJDUuWKzNq90iQX6++62veAdoJR4EX+arJbhfQl/oLCeExI3nlP00qx6jku/AIO6lsdW8kwmeEeiD1BjC1btwQaeJ6Vx+eex02ZO27CSyulzDB3KttrKcfwnxwgjDzi8oNy2WhnHN6nNH7S9+dbhzGo50dJeQhdQUHKqHPBnAvHJBhuYsy3xaOD0n2Ys3ixT1lAsjwwPBstC/4T8TgBJ1HcxINCYwjnUZNc5JKhZLTh37HZCl5ROuANeaJDSbKvjwIf7bXIBO5+5xsgWtRbbXz3KQ04hTSVCuDaPbG/TPyQIMafgGuTgEhcEoex7KZWMk8f1GecjlJcit7v2VidFahdbRPZxF+HRugw6rVHxhfhjZdgZRpBWi3O9YGoJrQx7C6DgkKK3xrATOK0lmQ=

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,22 +2,37 @@ dist: trusty
 language: c
 sudo: required
 compiler:
-  - clang
-  - gcc
-  - i686-w64-mingw32-gcc
+- clang
+- gcc
+- i686-w64-mingw32-gcc
 os:
-  - linux
-  - osx
-
+- linux
+- osx
 before_install:
-  - if [[ "$CC" == "i686-w64-mingw32-gcc" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo dpkg --add-architecture i386                       ; fi
-  - if [[ "$CC" == "i686-w64-mingw32-gcc" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:ubuntu-wine/ppa          ; fi
-  - if [[ "$CC" == "i686-w64-mingw32-gcc" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq                                 ; fi
-  - if [[ "$CC" == "i686-w64-mingw32-gcc" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get remove -qq -y mingw32                      ; fi
-  - if [[ "$CC" == "i686-w64-mingw32-gcc" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -q -y mingw-w64                    ; fi
-  - if [[ "$CC" == "i686-w64-mingw32-gcc" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install --no-install-recommends -y wine1.8 ; fi
-  - if [[ "$CC" == "i686-w64-mingw32-gcc" ]] && [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install mingw-w64                                    ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install jq                                                                                    ; fi
-
-# Can't get Wine to work on OSX, so skip runnning tests on that combo (only do a build) 
-script: if [[ "$CC" == "i686-w64-mingw32-gcc" ]] && [[ "$TRAVIS_OS_NAME" == "osx" ]]; then make CC=${CC} cli; else make CC=${CC} ; fi
+- if [[ "$CC" == "i686-w64-mingw32-gcc" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]];
+  then sudo dpkg --add-architecture i386                       ; fi
+- if [[ "$CC" == "i686-w64-mingw32-gcc" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]];
+  then sudo add-apt-repository -y ppa:ubuntu-wine/ppa          ; fi
+- if [[ "$CC" == "i686-w64-mingw32-gcc" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]];
+  then sudo apt-get update -qq                                 ; fi
+- if [[ "$CC" == "i686-w64-mingw32-gcc" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]];
+  then sudo apt-get remove -qq -y mingw32                      ; fi
+- if [[ "$CC" == "i686-w64-mingw32-gcc" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]];
+  then sudo apt-get install -q -y mingw-w64                    ; fi
+- if [[ "$CC" == "i686-w64-mingw32-gcc" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]];
+  then sudo apt-get install --no-install-recommends -y wine1.8 ; fi
+- if [[ "$CC" == "i686-w64-mingw32-gcc" ]] && [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  brew install mingw-w64                                    ; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install jq                                                                                    ;
+  fi
+script: if [[ "$CC" == "i686-w64-mingw32-gcc" ]] && [[ "$TRAVIS_OS_NAME" == "osx"
+  ]]; then make CC=${CC} cli; else make CC=${CC} ; fi
+addons:
+  artifacts: true
+  s3_region: "eu-west-2"
+env:
+  global:
+  - ARTIFACTS_PATHS="./bin:./libs"
+  - ARTIFACTS_BUCKET=cucumber-releases
+  - secure: aaC95l0Tq63040to71E2WGQHGyW+5qq9T0cujbgtx7UlVKq3XJ4IdPt+gT+GO9EddLkrrQ+09T27G56RO9hjfLWd3Xxf4+TCIhUQUEp5yD2ApLBP/BM4UeRgwjZKaxdtXsLcv8B8FNWAlZ0IyvA6TssZLge2gXIECm7yfJFJlQhjP0exmP5AN1YaC8IV8KwNT2rx8JZo5Q2nERKH0MCtuPCGdAIBCqZbrYwLj//FMl+YSTuzpAGiqXXosgSIsNJwIrKNJckEMoB7ZDWLCsCdzSZKNabpPd1yqwNxM/5zncfQ7V0oXx6mY2iusR64d8Icq5HAdGe9g2Pwpsme1Ptydiw19dwFaxs1PSJwFRiRhkMZIRZFHzyCpOZg9Zr1uftyPmV7RfKI0FUvmkuYGF0VxDXwP7B/nKWTSNqBvTlZ48O5b3rslNLqFf20WF1Qvll2IZ3Dmj8tcZYa1Rr9fivWnCKUZVfcADG98lcyVgpi9sojb4nvGLGB7Ux8tQt9Ka0jfp/7eaXAf8LLGDXYSj1VHKw94vgnM0ESsjTFBMLUtjymvUaQPGZeiIzcA8m6jo6Sjatg+GBZKADZo4R351BotUWzsLCyYfS0k+HJFpKKjPFKdFZob+6B5yJUk18Xcnj3vo+P0L6v2EpEE70qzQuAmCFTUXpVPAqoYtnxko10i4Y=
+  - secure: Cm9A5zBoy2rbgTeh+70ZGyWgnoeiLzQwKPrC9EksWUNuOzTEfAsV5+2c+owb6DKshoI6tGye3tl61q36A1nhJgZ/DyjDoIOa+hi+IAbBw4u0CbFjEEbdbGxyoe0PbcBaLgDFMnvA1wzITisfhdVNoOhQIO+DhsuhpVn/fj14hUdi1s4vujSwZLIPPWUe7FT0B4tIsV0+wBflGdLa55j3oEIB6CyMFaa2v5xTFdqteiWlfapojJGQ20VQz9TerJFFdIMyKiPb5shsO9zd1ioxZRpL7iJDUuWKzNq90iQX6++62veAdoJR4EX+arJbhfQl/oLCeExI3nlP00qx6jku/AIO6lsdW8kwmeEeiD1BjC1btwQaeJ6Vx+eex02ZO27CSyulzDB3KttrKcfwnxwgjDzi8oNy2WhnHN6nNH7S9+dbhzGo50dJeQhdQUHKqHPBnAvHJBhuYsy3xaOD0n2Ys3ixT1lAsjwwPBstC/4T8TgBJ1HcxINCYwjnUZNc5JKhZLTh37HZCl5ROuANeaJDSbKvjwIf7bXIBO5+5xsgWtRbbXz3KQ04hTSVCuDaPbG/TPyQIMafgGuTgEhcEoex7KZWMk8f1GecjlJcit7v2VidFahdbRPZxF+HRugw6rVHxhfhjZdgZRpBWi3O9YGoJrQx7C6DgkKK3xrATOK0lmQ=

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ before_install:
 script: if [[ "$CC" == "i686-w64-mingw32-gcc" ]] && [[ "$TRAVIS_OS_NAME" == "osx"
   ]]; then make CC=${CC} cli; else make CC=${CC} ; fi
 addons:
-  artifacts: true
-  s3_region: "eu-west-2"
+  artifacts:
+    s3_region: "eu-west-2"
 env:
   global:
   - ARTIFACTS_PATHS="./bin:./libs"


### PR DESCRIPTION
Uploads artifacts to S3. Particularly useful for distributing `gherkin` executables.

`travis encrypt` modified the whole YAML file, which is why there are more edits than necessary.