### PR TITLE
Add math library to gherkin link libraries if required to use `log10`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,19 @@ add_library(gherkin SHARED ${GHERKIN_SRS})
 target_include_directories(gherkin PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_CURRENT_SOURCE_DIR}/src>")
 
+include(CheckSymbolExists)
+
+check_symbol_exists(log10 math.h RES)
+if(NOT RES)
+  list(APPEND CMAKE_REQUIRED_LIBRARIES m)
+  check_symbol_exists(log10 math.h RES2)
+  if(RES2)
+    target_link_libraries(gherkin PRIVATE m)
+  else()
+    message(FATAL_ERROR "No log10() found")
+  endif()
+endif()
+
 add_executable(gherkinexe ${GHERKIN_CLI})
 target_link_libraries(gherkinexe gherkin)
 target_include_directories(gherkinexe PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/src)


### PR DESCRIPTION
The current version doesn't build with GCC 8.1 (at least on my Arch
linux box) since the dependency to the math library is missing.