### PR TITLE
Rename `TokenScanner`s pointer to the deleter in order to allow use with C++

### DIFF
--- a/include/token_scanner.h
+++ b/include/token_scanner.h
@@ -17,7 +17,7 @@ typedef void (*delete_function) (TokenScanner*);
 
 struct TokenScanner {
     read_function read;
-    delete_function delete;
+    delete_function token_scanner_delete;
 };
 
 void TokenScanner_delete(TokenScanner* token_scanner);

--- a/src/file_token_scanner.c
+++ b/src/file_token_scanner.c
@@ -23,7 +23,7 @@ static void FileTokenScanner_delete(TokenScanner* token_scanner);
 TokenScanner* FileTokenScanner_new(const char* const file_name) {
     FileTokenScanner* token_scanner = (FileTokenScanner*)malloc(sizeof(FileTokenScanner));
     token_scanner->token_scanner.read = &FileTokenScanner_read;
-    token_scanner->token_scanner.delete = &FileTokenScanner_delete;
+    token_scanner->token_scanner.token_scanner_delete = &FileTokenScanner_delete;
     token_scanner->line = 0;
     token_scanner->file = 0;
     token_scanner->file = fopen(file_name, "rb");

--- a/src/string_token_scanner.c
+++ b/src/string_token_scanner.c
@@ -17,7 +17,7 @@ static void StringTokenScanner_delete(TokenScanner* token_scanner);
 TokenScanner* StringTokenScanner_new(const wchar_t* source) {
     StringTokenScanner* token_scanner = (StringTokenScanner*)malloc(sizeof(StringTokenScanner));
     token_scanner->token_scanner.read = &StringTokenScanner_read;
-    token_scanner->token_scanner.delete = &StringTokenScanner_delete;
+    token_scanner->token_scanner.token_scanner_delete = &StringTokenScanner_delete;
     token_scanner->source = source;
     token_scanner->line = 0;
     token_scanner->pos = 0;

--- a/src/token_scanner.c
+++ b/src/token_scanner.c
@@ -1,5 +1,5 @@
 #include "token_scanner.h"
 
 void TokenScanner_delete(TokenScanner* token_scanner) {
-    token_scanner->delete(token_scanner);
+    token_scanner->token_scanner_delete(token_scanner);
 }


### PR DESCRIPTION
Since `delete` is a keyword in C++, the current version of the header cannot be used in a C++ project. However, both the readme as well as the conditionally compiled `extern "C"` part in the header suggest that the author intended this library to be usable from C++ as is.

Since this is an API break I'm not sure if this is ok, but afaict users of the library aren't supposed to use the function pointer directly and are encouraged to use `TokenScanner_delete` instead. 