### PR TITLE
Export Public Gherkin API for Windows shared libaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-PROJECT(gherkin C)
+PROJECT(gherkin)
+include(GenerateExportHeader)
 cmake_minimum_required(VERSION 3.0)
 # Install library & headers in your directory
 #SET(CMAKE_INSTALL_PREFIX  "")
@@ -67,6 +68,16 @@ LIST(APPEND GHERKIN_CLI
 add_library(gherkin SHARED ${GHERKIN_SRS})
 target_include_directories(gherkin PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_CURRENT_SOURCE_DIR}/src>")
+	
+generate_export_header(gherkin
+    EXPORT_FILE_NAME "${CMAKE_CURRENT_SOURCE_DIR}/include/exports.h"
+)
+
+set_target_properties(
+    gherkin
+    PROPERTIES
+        DEFINE_SYMBOL gherkin_EXPORTS
+)
 
 add_executable(gherkinexe ${GHERKIN_CLI})
 target_link_libraries(gherkinexe gherkin)
@@ -91,6 +102,15 @@ FOREACH(ENTITY ${GOOD_FEATURE_FILES})
             DEPENDS invo
     )
 ENDFOREACH()
+
+############ Generic Compiler Flags ############
+
+if(CMAKE_C_COMPILER_ID MATCHES "GNU")
+    # CMake generates the GHERKIN_EXPORT attritbute with __attribute__((visibility("default")))
+    # in this case, and it being ignored is not relevant for us here.
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-attributes")
+endif()
+
 ############ Installation section ############
 set(include_install_dir "include")
 set(lib_install_dir "lib/")

--- a/include/ast_builder.h
+++ b/include/ast_builder.h
@@ -8,11 +8,11 @@
 extern "C" {
 #endif
 
-Builder* AstBuilder_new();
+GHERKIN_EXPORT Builder* AstBuilder_new();
 
-void AstBuilder_delete(Builder* builder);
+GHERKIN_EXPORT void AstBuilder_delete(Builder* builder);
 
-const GherkinDocument* AstBuilder_get_result(Builder* builder);
+GHERKIN_EXPORT const GherkinDocument* AstBuilder_get_result(Builder* builder);
 
 #ifdef __cplusplus
 }

--- a/include/attachment_event.h
+++ b/include/attachment_event.h
@@ -3,6 +3,7 @@
 
 #include <wchar.h>
 
+#include "exports.h"
 #include "event.h"
 #include "error.h"
 
@@ -17,9 +18,9 @@ typedef struct AttachmentEvent {
     const wchar_t* data;
 } AttachmentEvent;
 
-AttachmentEvent* AttachmentEvent_new(const char* uri, const Location location);
+GHERKIN_EXPORT AttachmentEvent* AttachmentEvent_new(const char* uri, const Location location);
 
-void AttacnmentEvent_transfer_error_text(AttachmentEvent* attachment_event, Error* error);
+GHERKIN_EXPORT void AttacnmentEvent_transfer_error_text(AttachmentEvent* attachment_event, Error* error);
 
 #ifdef __cplusplus
 }

--- a/include/background.h
+++ b/include/background.h
@@ -3,6 +3,7 @@
 
 #include <wchar.h>
 
+#include "exports.h"
 #include "ast.h"
 #include "location.h"
 #include "step.h"
@@ -21,9 +22,9 @@ typedef struct Background {
     const Steps* steps;
 } Background;
 
-const Background* Background_new(Location location, const wchar_t* keyword, const wchar_t* name, const wchar_t* description, const Steps* steps);
+GHERKIN_EXPORT const Background* Background_new(Location location, const wchar_t* keyword, const wchar_t* name, const wchar_t* description, const Steps* steps);
 
-void Background_delete(const Background* background);
+GHERKIN_EXPORT void Background_delete(const Background* background);
 
 #ifdef __cplusplus
 }

--- a/include/builder.h
+++ b/include/builder.h
@@ -7,13 +7,13 @@
 
 typedef struct Builder Builder;
 
-typedef void (*builder_reset_function) (Builder*);
+GHERKIN_EXPORT typedef void (*builder_reset_function) (Builder*);
 
-typedef void (*builder_error_context_function) (Builder*, ErrorList*);
+GHERKIN_EXPORT typedef void (*builder_error_context_function) (Builder*, ErrorList*);
 
-typedef void (*build_function) (Builder*, Token*);
+GHERKIN_EXPORT typedef void (*build_function) (Builder*, Token*);
 
-typedef void (*rule_function) (Builder*, RuleType);
+GHERKIN_EXPORT typedef void (*rule_function) (Builder*, RuleType);
 
 struct Builder {
     builder_reset_function reset;

--- a/include/comment.h
+++ b/include/comment.h
@@ -5,6 +5,7 @@
 
 #include "ast.h"
 #include "location.h"
+#include "exports.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -22,13 +23,13 @@ typedef struct Comments {
     Comment* comments;
 } Comments;
 
-Comment* Comment_new(Location location, const wchar_t* text);
+GHERKIN_EXPORT Comment* Comment_new(Location location, const wchar_t* text);
 
-void Comment_delete(const Comment* comment);
+GHERKIN_EXPORT void Comment_delete(const Comment* comment);
 
-void Comment_transfer(Comment* to_comment, Comment* from_comment);
+GHERKIN_EXPORT void Comment_transfer(Comment* to_comment, Comment* from_comment);
 
-void Comments_delete(const Comments* comments);
+GHERKIN_EXPORT void Comments_delete(const Comments* comments);
 
 #ifdef __cplusplus
 }

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -3,6 +3,8 @@
 
 #include <stdbool.h>
 #include <wchar.h>
+
+#include "exports.h"
 #include "gherkin_document.h"
 #include "pickle.h"
 
@@ -12,19 +14,19 @@ extern "C" {
 
 typedef struct Compiler Compiler;
 
-Compiler* Compiler_new();
+GHERKIN_EXPORT Compiler* Compiler_new();
 
-void Compiler_delete(Compiler* compiler);
+GHERKIN_EXPORT void Compiler_delete(Compiler* compiler);
 
-int Compiler_compile(Compiler* compiler, const GherkinDocument* gherkin_document);
+GHERKIN_EXPORT int Compiler_compile(Compiler* compiler, const GherkinDocument* gherkin_document);
 
-bool Compiler_has_more_pickles(Compiler* compiler);
+GHERKIN_EXPORT bool Compiler_has_more_pickles(Compiler* compiler);
 
-const Pickle* Compiler_next_pickle(Compiler* compiler);
+GHERKIN_EXPORT const Pickle* Compiler_next_pickle(Compiler* compiler);
 
-bool Compiler_has_more_errors(Compiler* compiler);
+GHERKIN_EXPORT bool Compiler_has_more_errors(Compiler* compiler);
 
-const wchar_t* Compiler_next_error(Compiler* compiler);
+GHERKIN_EXPORT const wchar_t* Compiler_next_error(Compiler* compiler);
 
 #ifdef __cplusplus
 }

--- a/include/data_table.h
+++ b/include/data_table.h
@@ -16,11 +16,11 @@ typedef struct DataTable {
     const TableRows* rows;
 } DataTable;
 
-const DataTable* DataTable_new(Location location, const TableRows* rows);
+GHERKIN_EXPORT const DataTable* DataTable_new(Location location, const TableRows* rows);
 
-void DataTable_delete(const DataTable* data_table);
+GHERKIN_EXPORT void DataTable_delete(const DataTable* data_table);
 
-void DataTable_transfer(DataTable* to_data_table, DataTable* from_data_table);
+GHERKIN_EXPORT void DataTable_transfer(DataTable* to_data_table, DataTable* from_data_table);
 
 #ifdef __cplusplus
 }

--- a/include/dialect.h
+++ b/include/dialect.h
@@ -3,6 +3,8 @@
 
 #include <wchar.h>
 
+#include "exports.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -26,7 +28,7 @@ typedef struct Dialect {
     const Keywords* when_keywords;
 } Dialect;
 
-const Dialect* Dialect_for(const wchar_t* language);
+GHERKIN_EXPORT const Dialect* Dialect_for(const wchar_t* language);
 
 #ifdef __cplusplus
 }

--- a/include/doc_string.h
+++ b/include/doc_string.h
@@ -3,6 +3,7 @@
 
 #include <wchar.h>
 
+#include "exports.h"
 #include "ast.h"
 #include "location.h"
 
@@ -18,9 +19,9 @@ typedef struct DocString {
     const wchar_t* content;
 } DocString;
 
-const DocString* DocString_new(Location location, const wchar_t* content_type, const wchar_t* content);
+GHERKIN_EXPORT const DocString* DocString_new(Location location, const wchar_t* content_type, const wchar_t* content);
 
-void DocString_delete(const DocString* doc_string);
+GHERKIN_EXPORT void DocString_delete(const DocString* doc_string);
 
 #ifdef __cplusplus
 }

--- a/include/error.h
+++ b/include/error.h
@@ -1,8 +1,10 @@
 #ifndef GHERKIN_ERROR_H_
 #define GHERKIN_ERROR_H_
 
+#include "exports.h"
 #include "item.h"
 #include "location.h"
+
 #include <wchar.h>
 
 #ifdef __cplusplus
@@ -15,9 +17,9 @@ typedef struct Error {
     const wchar_t* error_text;
 } Error;
 
-const Error* Error_new(const wchar_t* error_text, const Location location);
+GHERKIN_EXPORT const Error* Error_new(const wchar_t* error_text, const Location location);
 
-void Error_delete(const Error* error);
+GHERKIN_EXPORT void Error_delete(const Error* error);
 
 #ifdef __cplusplus
 }

--- a/include/error_list.h
+++ b/include/error_list.h
@@ -1,8 +1,10 @@
 #ifndef GHERKIN_ERROR_LIST_H_
 #define GHERKIN_ERROR_LIST_H_
 
+#include "exports.h"
 #include "error.h"
 #include "token.h"
+
 #include <stdbool.h>
 #include <setjmp.h>
 #include <wchar.h>
@@ -13,37 +15,37 @@ extern "C" {
 
 typedef struct ErrorList ErrorList;
 
-ErrorList* ErrorList_new();
+GHERKIN_EXPORT ErrorList* ErrorList_new();
 
-void ErrorList_delete(ErrorList* error_list);
+GHERKIN_EXPORT void ErrorList_delete(ErrorList* error_list);
 
-void ErrorList_set_global_rescue_env(ErrorList* error_list, jmp_buf* env);
+GHERKIN_EXPORT void ErrorList_set_global_rescue_env(ErrorList* error_list, jmp_buf* env);
 
-void ErrorList_set_local_rescue_env(ErrorList* error_list, jmp_buf* env);
+GHERKIN_EXPORT void ErrorList_set_local_rescue_env(ErrorList* error_list, jmp_buf* env);
 
-void ErrorList_jump_to_global_rescue_env(ErrorList* error_list);
+GHERKIN_EXPORT void ErrorList_jump_to_global_rescue_env(ErrorList* error_list);
 
-void ErrorList_jump_to_local_rescue_env(ErrorList* error_list);
+GHERKIN_EXPORT void ErrorList_jump_to_local_rescue_env(ErrorList* error_list);
 
-bool ErrorList_is_empty(ErrorList* error_list);
+GHERKIN_EXPORT bool ErrorList_is_empty(ErrorList* error_list);
 
-void ErrorList_add(ErrorList* error_list, const wchar_t* error, const Location location);
+GHERKIN_EXPORT void ErrorList_add(ErrorList* error_list, const wchar_t* error, const Location location);
 
-void ErrorList_add_unexpected_eof_error(ErrorList* error_list, Token* received_token, const wchar_t* expected_tokens);
+GHERKIN_EXPORT void ErrorList_add_unexpected_eof_error(ErrorList* error_list, Token* received_token, const wchar_t* expected_tokens);
 
-void ErrorList_add_unexpected_token_error(ErrorList* error_list, Token* received_token, const wchar_t* expected_tokens);
+GHERKIN_EXPORT void ErrorList_add_unexpected_token_error(ErrorList* error_list, Token* received_token, const wchar_t* expected_tokens);
 
-void ErrorList_add_no_such_language_error(ErrorList* error_list, Location* location, const wchar_t* language);
+GHERKIN_EXPORT void ErrorList_add_no_such_language_error(ErrorList* error_list, Location* location, const wchar_t* language);
 
-void ErrorList_add_inconsisten_cell_count_error(ErrorList* error_list, Location location);
+GHERKIN_EXPORT void ErrorList_add_inconsisten_cell_count_error(ErrorList* error_list, Location location);
 
-void ErrorList_internal_grammar_error(ErrorList* error_list);
+GHERKIN_EXPORT void ErrorList_internal_grammar_error(ErrorList* error_list);
 
-void ErrorList_add_invalid_operation_error(ErrorList* error_list, int state);
+GHERKIN_EXPORT void ErrorList_add_invalid_operation_error(ErrorList* error_list, int state);
 
-bool ErrorList_has_more_errors(ErrorList* error_list);
+GHERKIN_EXPORT bool ErrorList_has_more_errors(ErrorList* error_list);
 
-Error* ErrorList_next_error(ErrorList* error_list);
+GHERKIN_EXPORT Error* ErrorList_next_error(ErrorList* error_list);
 
 #ifdef __cplusplus
 }

--- a/include/event.h
+++ b/include/event.h
@@ -3,15 +3,17 @@
 
 #include <stdio.h>
 
+#include "exports.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct Event Event;
 
-typedef void (*event_delete_function) (const Event*);
+GHERKIN_EXPORT typedef void (*event_delete_function) (const Event*);
 
-typedef void (*event_print_function) (const Event*, FILE* file);
+GHERKIN_EXPORT typedef void (*event_print_function) (const Event*, FILE* file);
 
 typedef enum EventType {
     Gherkin_SourceEvent,
@@ -26,9 +28,9 @@ struct Event {
     EventType event_type;
 };
 
-void Event_delete(const Event* event);
+GHERKIN_EXPORT void Event_delete(const Event* event);
 
-void Event_print(const Event* event, FILE* file);
+GHERKIN_EXPORT void Event_print(const Event* event, FILE* file);
 
 #ifdef __cplusplus
 }

--- a/include/example_table.h
+++ b/include/example_table.h
@@ -29,13 +29,13 @@ typedef struct Examples {
     ExampleTable* example_table;
 } Examples;
 
-const ExampleTable* ExampleTable_new(Location location, const wchar_t* keyword, const wchar_t* name, const wchar_t* description, const Tags* tags, const TableRow* table_header, const TableRows* table_body);
+GHERKIN_EXPORT const ExampleTable* ExampleTable_new(Location location, const wchar_t* keyword, const wchar_t* name, const wchar_t* description, const Tags* tags, const TableRow* table_header, const TableRows* table_body);
 
-void ExampleTable_delete(const ExampleTable* example_table);
+GHERKIN_EXPORT void ExampleTable_delete(const ExampleTable* example_table);
 
-void ExampleTable_transfer(ExampleTable* to_example_table, ExampleTable* from_example_table);
+GHERKIN_EXPORT void ExampleTable_transfer(ExampleTable* to_example_table, ExampleTable* from_example_table);
 
-void Examples_delete(const Examples* examples);
+GHERKIN_EXPORT void Examples_delete(const Examples* examples);
 
 #ifdef __cplusplus
 }

--- a/include/feature.h
+++ b/include/feature.h
@@ -25,9 +25,9 @@ typedef struct Feature {
     const ScenarioDefinitions* scenario_definitions;
 } Feature;
 
-const Feature* Feature_new(Location location, const wchar_t* language, const wchar_t* keyword, const wchar_t* name, const wchar_t* description, const Tags* tags, const ScenarioDefinitions* scenario_definitions);
+GHERKIN_EXPORT const Feature* Feature_new(Location location, const wchar_t* language, const wchar_t* keyword, const wchar_t* name, const wchar_t* description, const Tags* tags, const ScenarioDefinitions* scenario_definitions);
 
-void Feature_delete(const Feature* feature);
+GHERKIN_EXPORT void Feature_delete(const Feature* feature);
 
 #ifdef __cplusplus
 }

--- a/include/file_reader.h
+++ b/include/file_reader.h
@@ -3,17 +3,19 @@
 
 #include <wchar.h>
 
+#include "exports.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct FileReader FileReader;
 
-FileReader* FileReader_new(const char* const file_name);
+GHERKIN_EXPORT FileReader* FileReader_new(const char* const file_name);
 
-const wchar_t* FileReader_read(FileReader* file_reader);
+GHERKIN_EXPORT const wchar_t* FileReader_read(FileReader* file_reader);
 
-void FileReader_delete(FileReader* file_reader);
+GHERKIN_EXPORT void FileReader_delete(FileReader* file_reader);
 
 #ifdef __cplusplus
 }

--- a/include/file_token_scanner.h
+++ b/include/file_token_scanner.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-TokenScanner* FileTokenScanner_new(const char* const file_name);
+GHERKIN_EXPORT TokenScanner* FileTokenScanner_new(const char* const file_name);
 
 #ifdef __cplusplus
 }

--- a/include/gherkin_document.h
+++ b/include/gherkin_document.h
@@ -16,9 +16,9 @@ typedef struct GherkinDocument {
     const Comments* comments;
 } GherkinDocument;
 
-const GherkinDocument* GherkinDocument_new(const Feature* feature, const Comments* comments);
+GHERKIN_EXPORT const GherkinDocument* GherkinDocument_new(const Feature* feature, const Comments* comments);
 
-void GherkinDocument_delete(const GherkinDocument* gherkin_document);
+GHERKIN_EXPORT void GherkinDocument_delete(const GherkinDocument* gherkin_document);
 
 #ifdef __cplusplus
 }

--- a/include/gherkin_document_event.h
+++ b/include/gherkin_document_event.h
@@ -16,7 +16,7 @@ typedef struct GherkinDocumentEvent {
     const GherkinDocument* gherkin_document;
 } GherkinDocumentEvent;
 
-const GherkinDocumentEvent* GherkinDocumentEvent_new(const char* uri, const GherkinDocument* gherkin_document);
+GHERKIN_EXPORT const GherkinDocumentEvent* GherkinDocumentEvent_new(const char* uri, const GherkinDocument* gherkin_document);
 
 #ifdef __cplusplus
 }

--- a/include/gherkin_line.h
+++ b/include/gherkin_line.h
@@ -4,6 +4,8 @@
 #include <stdbool.h>
 #include <wchar.h>
 
+#include "exports.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -25,27 +27,27 @@ typedef struct Items {
     Span* items;
 } Items;
 
-const GherkinLine* GherkinLine_new(const wchar_t* line_text, int line_number);
+GHERKIN_EXPORT const GherkinLine* GherkinLine_new(const wchar_t* line_text, int line_number);
 
-void GherkinLine_delete(const GherkinLine* line);
+GHERKIN_EXPORT void GherkinLine_delete(const GherkinLine* line);
 
-bool GherkinLine_start_with(const GherkinLine* line, const wchar_t* prefix);
+GHERKIN_EXPORT bool GherkinLine_start_with(const GherkinLine* line, const wchar_t* prefix);
 
-bool GherkinLine_start_with_title_keyword(const GherkinLine* line, const wchar_t* keyword);
+GHERKIN_EXPORT bool GherkinLine_start_with_title_keyword(const GherkinLine* line, const wchar_t* keyword);
 
-bool GherkinLine_is_empty(const GherkinLine* line);
+GHERKIN_EXPORT bool GherkinLine_is_empty(const GherkinLine* line);
 
-wchar_t* GherkinLine_copy_rest_trimmed(const GherkinLine* line, int length);
+GHERKIN_EXPORT wchar_t* GherkinLine_copy_rest_trimmed(const GherkinLine* line, int length);
 
-wchar_t* GherkinLine_copy_line_text(const GherkinLine* line, int indent_to_remove);
+GHERKIN_EXPORT wchar_t* GherkinLine_copy_line_text(const GherkinLine* line, int indent_to_remove);
 
-const Items* GherkinLine_table_cells(const GherkinLine* line);
+GHERKIN_EXPORT const Items* GherkinLine_table_cells(const GherkinLine* line);
 
-const Items* GherkinLine_tags(const GherkinLine* line);
+GHERKIN_EXPORT const Items* GherkinLine_tags(const GherkinLine* line);
 
-bool GherkinLine_is_language_line(const GherkinLine* line);
+GHERKIN_EXPORT bool GherkinLine_is_language_line(const GherkinLine* line);
 
-const wchar_t* GherkinLine_get_language(const GherkinLine* line);
+GHERKIN_EXPORT const wchar_t* GherkinLine_get_language(const GherkinLine* line);
 
 
 #ifdef __cplusplus

--- a/include/parser.h
+++ b/include/parser.h
@@ -14,15 +14,15 @@ extern "C" {
 
 typedef struct Parser Parser;
 
-Parser* Parser_new(Builder* builder);
+GHERKIN_EXPORT Parser* Parser_new(Builder* builder);
 
-void Parser_delete(Parser* parser);
+GHERKIN_EXPORT void Parser_delete(Parser* parser);
 
-int Parser_parse(Parser* parser, TokenMatcher* token_matcher, TokenScanner* token_scanner);
+GHERKIN_EXPORT int Parser_parse(Parser* parser, TokenMatcher* token_matcher, TokenScanner* token_scanner);
 
-bool Parser_has_more_errors(Parser* parser);
+GHERKIN_EXPORT bool Parser_has_more_errors(Parser* parser);
 
-Error* Parser_next_error(Parser* parser);
+GHERKIN_EXPORT Error* Parser_next_error(Parser* parser);
 
 #ifdef __cplusplus
 }

--- a/include/pickle.h
+++ b/include/pickle.h
@@ -21,9 +21,9 @@ typedef struct Pickle {
     const PickleSteps* steps;
 } Pickle;
 
-const Pickle* Pickle_new(const wchar_t* language, const PickleLocations* locations, const PickleTags* tags, const wchar_t* name, const PickleSteps* steps);
+GHERKIN_EXPORT const Pickle* Pickle_new(const wchar_t* language, const PickleLocations* locations, const PickleTags* tags, const wchar_t* name, const PickleSteps* steps);
 
-void Pickle_delete(const Pickle* pickle);
+GHERKIN_EXPORT void Pickle_delete(const Pickle* pickle);
 
 #ifdef __cplusplus
 }

--- a/include/pickle_cell.h
+++ b/include/pickle_cell.h
@@ -19,13 +19,13 @@ typedef struct PickleCells {
     PickleCell* pickle_cells;
 } PickleCells;
 
-const PickleCell* PickleCell_new(const PickleLocation* location, const wchar_t* value);
+GHERKIN_EXPORT const PickleCell* PickleCell_new(const PickleLocation* location, const wchar_t* value);
 
-void PickleCell_delete(const PickleCell* pickle_cell);
+GHERKIN_EXPORT void PickleCell_delete(const PickleCell* pickle_cell);
 
-void PickleCell_transfer(PickleCell* to_pickle_cell, PickleCell* from_pickle_cell);
+GHERKIN_EXPORT void PickleCell_transfer(PickleCell* to_pickle_cell, PickleCell* from_pickle_cell);
 
-void PickleCells_delete(const PickleCells* pickle_cells);
+GHERKIN_EXPORT void PickleCells_delete(const PickleCells* pickle_cells);
 
 #ifdef __cplusplus
 }

--- a/include/pickle_event.h
+++ b/include/pickle_event.h
@@ -16,7 +16,7 @@ typedef struct PickleEvent {
     const Pickle* pickle;
 } PickleEvent;
 
-const PickleEvent* PickleEvent_new(const char* uri, const Pickle* pickle);
+GHERKIN_EXPORT const PickleEvent* PickleEvent_new(const char* uri, const Pickle* pickle);
 
 #ifdef __cplusplus
 }

--- a/include/pickle_location.h
+++ b/include/pickle_location.h
@@ -1,6 +1,8 @@
 #ifndef GHERKIN_PICKLE_LOCATION_H_
 #define GHERKIN_PICKLE_LOCATION_H_
 
+#include "exports.h"
+
 typedef struct PickleLocation {
     int line;
     int column;
@@ -11,14 +13,14 @@ typedef struct PickleLocations {
     const PickleLocation* locations;
 } PickleLocations;
 
-const PickleLocation* PickleLocation_new(int line, int column);
+GHERKIN_EXPORT const PickleLocation* PickleLocation_new(int line, int column);
 
-const PickleLocations* PickleLocations_new_single(int line, int column);
+GHERKIN_EXPORT const PickleLocations* PickleLocations_new_single(int line, int column);
 
-const PickleLocations* PickleLocations_new_double(int line_1, int column_1, int line_2, int column_2);
+GHERKIN_EXPORT const PickleLocations* PickleLocations_new_double(int line_1, int column_1, int line_2, int column_2);
 
-void PickleLocations_delete(const PickleLocations* locations);
+GHERKIN_EXPORT void PickleLocations_delete(const PickleLocations* locations);
 
-void PickleLocation_delete(const PickleLocation* location);
+GHERKIN_EXPORT void PickleLocation_delete(const PickleLocation* location);
 
 #endif /* GHERKIN_PICKLE_LOCATION_H_ */

--- a/include/pickle_row.h
+++ b/include/pickle_row.h
@@ -16,13 +16,13 @@ typedef struct PickleRows {
     PickleRow* pickle_rows;
 } PickleRows;
 
-const PickleRow* PickleRow_new(const PickleCells* pickle_cells);
+GHERKIN_EXPORT const PickleRow* PickleRow_new(const PickleCells* pickle_cells);
 
-void PickleRow_delete(const PickleRow* pickle_row);
+GHERKIN_EXPORT void PickleRow_delete(const PickleRow* pickle_row);
 
-void PickleRow_transfer(PickleRow* to_pickle_row, PickleRow* from_pickle_row);
+GHERKIN_EXPORT void PickleRow_transfer(PickleRow* to_pickle_row, PickleRow* from_pickle_row);
 
-void PickleRows_delete(const PickleRows* pickle_rows);
+GHERKIN_EXPORT void PickleRows_delete(const PickleRows* pickle_rows);
 
 #ifdef __cplusplus
 }

--- a/include/pickle_step.h
+++ b/include/pickle_step.h
@@ -21,13 +21,13 @@ typedef struct PickleSteps {
     PickleStep* steps;
 } PickleSteps;
 
-const PickleStep* PickleStep_new(const PickleLocations* locations, const wchar_t* text, const PickleArgument* argument);
+GHERKIN_EXPORT const PickleStep* PickleStep_new(const PickleLocations* locations, const wchar_t* text, const PickleArgument* argument);
 
-void PickleStep_delete(const PickleStep* pickle_step);
+GHERKIN_EXPORT void PickleStep_delete(const PickleStep* pickle_step);
 
-void PickleStep_transfer(PickleStep* to_pickle_step, PickleStep* from_pickle_step);
+GHERKIN_EXPORT void PickleStep_transfer(PickleStep* to_pickle_step, PickleStep* from_pickle_step);
 
-void PickleSteps_delete(const PickleSteps* pickle_steps);
+GHERKIN_EXPORT void PickleSteps_delete(const PickleSteps* pickle_steps);
 
 #ifdef __cplusplus
 }

--- a/include/pickle_string.h
+++ b/include/pickle_string.h
@@ -17,9 +17,9 @@ typedef struct PickleString {
     wchar_t* content;
 } PickleString;
 
-const PickleString* PickleString_new(const wchar_t* content, int line, int column, const wchar_t* content_type);
+GHERKIN_EXPORT const PickleString* PickleString_new(const wchar_t* content, int line, int column, const wchar_t* content_type);
 
-void PickleString_delete(const PickleString* pickle_string);
+GHERKIN_EXPORT void PickleString_delete(const PickleString* pickle_string);
 
 #ifdef __cplusplus
 }

--- a/include/pickle_table.h
+++ b/include/pickle_table.h
@@ -13,9 +13,9 @@ typedef struct PickleTable {
     const PickleRows* rows;
 } PickleTable;
 
-const PickleTable* PickleTable_new(const PickleRows* rows);
+GHERKIN_EXPORT const PickleTable* PickleTable_new(const PickleRows* rows);
 
-void PickleTable_delete(const PickleTable* pickle_table);
+GHERKIN_EXPORT void PickleTable_delete(const PickleTable* pickle_table);
 
 #ifdef __cplusplus
 }

--- a/include/pickle_tag.h
+++ b/include/pickle_tag.h
@@ -19,11 +19,11 @@ typedef struct PickleTags {
     PickleTag* tags;
 } PickleTags;
 
-void PickleTag_delete(const PickleTag* tag);
+GHERKIN_EXPORT void PickleTag_delete(const PickleTag* tag);
 
-void PickleTag_transfer(PickleTag* to_tag, const wchar_t* name, int line, int column);
+GHERKIN_EXPORT void PickleTag_transfer(PickleTag* to_tag, const wchar_t* name, int line, int column);
 
-void PickleTags_delete(const PickleTags* tags);
+GHERKIN_EXPORT void PickleTags_delete(const PickleTags* tags);
 
 #ifdef __cplusplus
 }

--- a/include/scenario.h
+++ b/include/scenario.h
@@ -23,11 +23,11 @@ typedef struct Scenario {
     const Steps* steps;
 } Scenario;
 
-const Scenario* Scenario_new(Location location, const wchar_t* keyword, const wchar_t* name, const wchar_t* description, const Tags* tags, const Steps* steps);
+GHERKIN_EXPORT const Scenario* Scenario_new(Location location, const wchar_t* keyword, const wchar_t* name, const wchar_t* description, const Tags* tags, const Steps* steps);
 
-void Scenario_delete(const Scenario* scenario);
+GHERKIN_EXPORT void Scenario_delete(const Scenario* scenario);
 
-void Scenario_transfer(Scenario* to_scenario, Scenario* from_scenario);
+GHERKIN_EXPORT void Scenario_transfer(Scenario* to_scenario, Scenario* from_scenario);
 
 #ifdef __cplusplus
 }

--- a/include/scenario_outline.h
+++ b/include/scenario_outline.h
@@ -25,11 +25,11 @@ typedef struct ScenarioOutline {
     const Examples* examples;
 } ScenarioOutline;
 
-const ScenarioOutline* ScenarioOutline_new(Location location, const wchar_t* keyword, const wchar_t* name, const wchar_t* description, const Tags* tags, const Steps* steps, const Examples* examples);
+GHERKIN_EXPORT const ScenarioOutline* ScenarioOutline_new(Location location, const wchar_t* keyword, const wchar_t* name, const wchar_t* description, const Tags* tags, const Steps* steps, const Examples* examples);
 
-void ScenarioOutline_delete(const ScenarioOutline* scenario_outline);
+GHERKIN_EXPORT void ScenarioOutline_delete(const ScenarioOutline* scenario_outline);
 
-void ScenarioOutline_transfer(ScenarioOutline* to_scenario_outline, ScenarioOutline* from_scenario_outline);
+GHERKIN_EXPORT void ScenarioOutline_transfer(ScenarioOutline* to_scenario_outline, ScenarioOutline* from_scenario_outline);
 
 #ifdef __cplusplus
 }

--- a/include/source_event.h
+++ b/include/source_event.h
@@ -2,6 +2,7 @@
 #define GHERKIN_SOURCE_EVENT_H_
 
 #include "event.h"
+#include "exports.h"
 
 #include <wchar.h>
 
@@ -15,7 +16,7 @@ typedef struct SourceEvent {
     const wchar_t* source;
 } SourceEvent;
 
-SourceEvent* SourceEvent_new(const char* uri, const wchar_t* source);
+GHERKIN_EXPORT SourceEvent* SourceEvent_new(const char* uri, const wchar_t* source);
 
 #ifdef __cplusplus
 }

--- a/include/step.h
+++ b/include/step.h
@@ -3,6 +3,7 @@
 
 #include <wchar.h>
 
+#include "exports.h"
 #include "ast.h"
 #include "location.h"
 
@@ -29,13 +30,13 @@ typedef struct Steps {
     Step* steps;
 } Steps;
 
-const Step* Step_new(Location location, const wchar_t* keyword, const wchar_t* text, const StepArgument* argument);
+GHERKIN_EXPORT const Step* Step_new(Location location, const wchar_t* keyword, const wchar_t* text, const StepArgument* argument);
 
-void Step_delete(const Step* step);
+GHERKIN_EXPORT void Step_delete(const Step* step);
 
-void Step_transfer(Step* to_step, Step* from_step);
+GHERKIN_EXPORT void Step_transfer(Step* to_step, Step* from_step);
 
-void Steps_delete(const Steps* steps);
+GHERKIN_EXPORT void Steps_delete(const Steps* steps);
 
 #ifdef __cplusplus
 }

--- a/include/string_token_scanner.h
+++ b/include/string_token_scanner.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-TokenScanner* StringTokenScanner_new(const wchar_t* const source);
+GHERKIN_EXPORT TokenScanner* StringTokenScanner_new(const wchar_t* const source);
 
 #ifdef __cplusplus
 }

--- a/include/table_cell.h
+++ b/include/table_cell.h
@@ -3,6 +3,7 @@
 
 #include <wchar.h>
 
+#include "exports.h"
 #include "ast.h"
 #include "location.h"
 
@@ -22,13 +23,13 @@ typedef struct TableCells {
     TableCell* table_cells;
 } TableCells;
 
-const TableCell* TableCell_new(Location location, const wchar_t* value);
+GHERKIN_EXPORT const TableCell* TableCell_new(Location location, const wchar_t* value);
 
-void TableCell_delete(const TableCell* table_cell);
+GHERKIN_EXPORT void TableCell_delete(const TableCell* table_cell);
 
-void TableCell_transfer(TableCell* to_table_cell, TableCell* from_table_cell);
+GHERKIN_EXPORT void TableCell_transfer(TableCell* to_table_cell, TableCell* from_table_cell);
 
-void TableCells_delete(const TableCells* table_cells);
+GHERKIN_EXPORT void TableCells_delete(const TableCells* table_cells);
 
 #ifdef __cplusplus
 }

--- a/include/table_row.h
+++ b/include/table_row.h
@@ -22,13 +22,13 @@ typedef struct TableRows {
     TableRow* table_rows;
 } TableRows;
 
-const TableRow* TableRow_new(Location location, const TableCells* table_cells);
+GHERKIN_EXPORT const TableRow* TableRow_new(Location location, const TableCells* table_cells);
 
-void TableRow_delete(const TableRow* table_row);
+GHERKIN_EXPORT void TableRow_delete(const TableRow* table_row);
 
-void TableRow_transfer(TableRow* to_table_row, TableRow* from_table_row);
+GHERKIN_EXPORT void TableRow_transfer(TableRow* to_table_row, TableRow* from_table_row);
 
-void TableRows_delete(const TableRows* table_rows);
+GHERKIN_EXPORT void TableRows_delete(const TableRows* table_rows);
 
 #ifdef __cplusplus
 }

--- a/include/tag.h
+++ b/include/tag.h
@@ -3,6 +3,7 @@
 
 #include <wchar.h>
 
+#include "exports.h"
 #include "ast.h"
 #include "location.h"
 
@@ -22,13 +23,13 @@ typedef struct Tags {
     Tag* tags;
 } Tags;
 
-const Tag* Tag_new(Location location, const wchar_t* name);
+GHERKIN_EXPORT const Tag* Tag_new(Location location, const wchar_t* name);
 
-void Tag_delete(const Tag* tag);
+GHERKIN_EXPORT void Tag_delete(const Tag* tag);
 
-void Tag_transfer(Tag* to_tag, Location location, wchar_t** name_ptr);
+GHERKIN_EXPORT void Tag_transfer(Tag* to_tag, Location location, wchar_t** name_ptr);
 
-void Tags_delete(const Tags* tags);
+GHERKIN_EXPORT void Tags_delete(const Tags* tags);
 
 #ifdef __cplusplus
 }

--- a/include/token.h
+++ b/include/token.h
@@ -2,6 +2,8 @@
 #define GHERKIN_TOKEN_H_
 
 #include <wchar.h>
+
+#include "exports.h"
 #include "item.h"
 #include "location.h"
 #include "gherkin_line.h"
@@ -40,13 +42,13 @@ typedef struct Token {
     const wchar_t* matched_language;
 } Token;
 
-Token* Token_new(const GherkinLine* gherkin_line, int line);
+GHERKIN_EXPORT Token* Token_new(const GherkinLine* gherkin_line, int line);
 
-void Token_delete(Token* token);
+GHERKIN_EXPORT void Token_delete(Token* token);
 
-void Token_delete_matched_items(const Items* items);
+GHERKIN_EXPORT void Token_delete_matched_items(const Items* items);
 
-bool Token_is_eof(Token* token);
+GHERKIN_EXPORT bool Token_is_eof(Token* token);
 
 #ifdef __cplusplus
 }

--- a/include/token_matcher.h
+++ b/include/token_matcher.h
@@ -12,9 +12,9 @@ extern "C" {
 
 typedef struct TokenMatcher TokenMatcher;
 
-typedef void (*matcher_reset_function) (TokenMatcher*);
+GHERKIN_EXPORT typedef void (*matcher_reset_function) (TokenMatcher*);
 
-typedef bool (*match_function) (TokenMatcher*, Token*);
+GHERKIN_EXPORT typedef bool (*match_function) (TokenMatcher*, Token*);
 
 struct TokenMatcher {
     const wchar_t* default_language;
@@ -40,9 +40,9 @@ struct TokenMatcher {
     match_function match_EOF;
 };
 
-TokenMatcher* TokenMatcher_new(const wchar_t* default_language);
+GHERKIN_EXPORT TokenMatcher* TokenMatcher_new(const wchar_t* default_language);
 
-void TokenMatcher_delete(TokenMatcher* token_matcher);
+GHERKIN_EXPORT void TokenMatcher_delete(TokenMatcher* token_matcher);
 
 #ifdef __cplusplus
 }

--- a/include/token_scanner.h
+++ b/include/token_scanner.h
@@ -3,6 +3,7 @@
 
 #include <wchar.h>
 
+#include "exports.h"
 #include "token.h"
 
 #ifdef __cplusplus
@@ -11,16 +12,16 @@ extern "C" {
 
 typedef struct TokenScanner TokenScanner;
 
-typedef Token* (*read_function) (TokenScanner*);
+GHERKIN_EXPORT typedef Token* (*read_function) (TokenScanner*);
 
-typedef void (*delete_function) (TokenScanner*);
+GHERKIN_EXPORT typedef void (*delete_function) (TokenScanner*);
 
 struct TokenScanner {
     read_function read;
     delete_function delete;
 };
 
-void TokenScanner_delete(TokenScanner* token_scanner);
+GHERKIN_EXPORT void TokenScanner_delete(TokenScanner* token_scanner);
 
 #ifdef __cplusplus
 }

--- a/include/token_scanner.h
+++ b/include/token_scanner.h
@@ -18,7 +18,7 @@ GHERKIN_EXPORT typedef void (*delete_function) (TokenScanner*);
 
 struct TokenScanner {
     read_function read;
-    delete_function delete;
+    delete_function scanner_delete;
 };
 
 GHERKIN_EXPORT void TokenScanner_delete(TokenScanner* token_scanner);

--- a/src/ast_printer.h
+++ b/src/ast_printer.h
@@ -1,14 +1,16 @@
 #ifndef GHERKIN_AST_PRINTER_H_
 #define GHERKIN_AST_PRINTER_H_
 
+#include "exports.h"
 #include "gherkin_document.h"
+
 #include <stdio.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void AstPrinter_print_gherkin_document(FILE* file, const GherkinDocument* gherkin_document);
+GHERKIN_EXPORT void AstPrinter_print_gherkin_document(FILE* file, const GherkinDocument* gherkin_document);
 
 #ifdef __cplusplus
 }

--- a/src/file_token_scanner.c
+++ b/src/file_token_scanner.c
@@ -23,7 +23,7 @@ static void FileTokenScanner_delete(TokenScanner* token_scanner);
 TokenScanner* FileTokenScanner_new(const char* const file_name) {
     FileTokenScanner* token_scanner = (FileTokenScanner*)malloc(sizeof(FileTokenScanner));
     token_scanner->token_scanner.read = &FileTokenScanner_read;
-    token_scanner->token_scanner.delete = &FileTokenScanner_delete;
+    token_scanner->token_scanner.scanner_delete = &FileTokenScanner_delete;
     token_scanner->line = 0;
     token_scanner->file = 0;
     token_scanner->file = fopen(file_name, "rb");

--- a/src/print_utilities.h
+++ b/src/print_utilities.h
@@ -4,13 +4,15 @@
 #include <stdio.h>
 #include <wchar.h>
 
+#include "exports.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void PrintUtilities_print_json_string(FILE* file, const wchar_t* text);
+GHERKIN_EXPORT void PrintUtilities_print_json_string(FILE* file, const wchar_t* text);
 
-void PrintUtilities_print_wide_string(FILE* file, const wchar_t* text);
+GHERKIN_EXPORT void PrintUtilities_print_wide_string(FILE* file, const wchar_t* text);
 
 #ifdef __cplusplus
 }

--- a/src/string_token_scanner.c
+++ b/src/string_token_scanner.c
@@ -17,7 +17,7 @@ static void StringTokenScanner_delete(TokenScanner* token_scanner);
 TokenScanner* StringTokenScanner_new(const wchar_t* source) {
     StringTokenScanner* token_scanner = (StringTokenScanner*)malloc(sizeof(StringTokenScanner));
     token_scanner->token_scanner.read = &StringTokenScanner_read;
-    token_scanner->token_scanner.delete = &StringTokenScanner_delete;
+    token_scanner->token_scanner.scanner_delete = &StringTokenScanner_delete;
     token_scanner->source = source;
     token_scanner->line = 0;
     token_scanner->pos = 0;

--- a/src/token_scanner.c
+++ b/src/token_scanner.c
@@ -1,5 +1,5 @@
 #include "token_scanner.h"
 
 void TokenScanner_delete(TokenScanner* token_scanner) {
-    token_scanner->delete(token_scanner);
+    token_scanner->scanner_delete(token_scanner);
 }


### PR DESCRIPTION
Addresses #11 and cucumber/cucumber#430

This also renames one of the "delete" functions to not use a C++ keyword, which causes a compilation error.